### PR TITLE
authorization key name correction

### DIFF
--- a/webhook-pre.md
+++ b/webhook-pre.md
@@ -151,7 +151,7 @@ For example, if you specify `purple unicorn` in the **Secret** field, you might 
 ```javascript
 const jwt = require('jsonwebtoken');
 ...
-const token = request.headers.authentication; // grab the "Authentication" header
+const token = request.headers.authorization; // grab the "Authorization" header
 try {
   const decoded = jwt.verify(token, 'purple unicorn');
 } catch(err) {


### PR DESCRIPTION
request.headers.authentication is not present in the header , it should be request.headers.authorization

Thanks for taking the time to contribute to the IBM Cloud docs! After you open your pull request, a maintainer should review it soon.

We don't merge changes directly in this repository because content is not published from here. However, we'll incorporate any changes in our upstream repository so that they're reflected in the docs.

### Description

<!--- Replace this text with a summary of the changes in this pull request. Include why the changes are needed and context about the changes. --->

###  Any other comments?

<!-- Add additional information or screenshots that you think we need.-->

---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
